### PR TITLE
Fix vite config outDir

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,7 @@
 export default {
   root: './src',
   publicDir: '../assets',
-  outDir: '../dist',
+  build: {
+    outDir: '../dist',
+  }
 }


### PR DESCRIPTION
Fix the wrong configuration of vite outDir to put the dist directory in the right place.