### PR TITLE
Simplify Landing Page Text

### DIFF
--- a/src/components/organisms/home.js
+++ b/src/components/organisms/home.js
@@ -2,11 +2,8 @@ import define from '../../utils/define.js';
 
 const template = () => /*html*/`
   <h1>
-    Welcome to mwmbl, the free, open-source and non-profit search engine.
+    A free, open-source, and non-profit search engine.
   </h1>
-  <p>
-    You can start searching by using the search bar above!
-  </p>
 `;
 
 export default define('home', class extends HTMLLIElement {


### PR DESCRIPTION
Aims to enhance the mobile experience of the search engine front end by simplifying the landing page text, especially for mobile users.

The current text contains unnecessary information that can be removed to create a cleaner and more concise interface.

Changes Made:

- Condensed the description of the search engine to "A free, open-source and non-profit search engine"
- Removed the instruction to "start searching by using the search bar above" as it is self-explanatory

![image](https://github.com/mwmbl/front-end/assets/11240246/5f1325a5-40fb-4eae-9436-55f4e343b8d1)

![image](https://github.com/mwmbl/front-end/assets/11240246/b49255af-5c4d-46e5-879c-48bbacccba3e)

This PR is related to a [comment](https://news.ycombinator.com/item?id=37566422) from the HN post.